### PR TITLE
Introduce porti for finding an unused port for running tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nrd": "^1.0.0",
     "object-assign": "^4.1.0",
     "phantomjs-prebuilt": "^2.1.14",
+    "porti": "^1.0.2",
     "raptor-renderer": "^1.4.6",
     "resolve-from": "^2.0.0"
   },


### PR DESCRIPTION
This PR introduces `porti`, which is used for finding unused ports. Before, `marko-devtools` always ran tests on port `8080`, which is also the default port for `marko-starter-demo`. You could not be running a demo app and run tests at the same time.

Additionally, some minor jshint fixes.