### PR TITLE
Use getComponent when dealing with marko v4 renderResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,17 @@ Returns a jQuery-compatible object for querying the rendered DOM. Utilizes [chee
 
 The output HTML string.
 
+#### `component`
+
+***In-browser only***
+
+Returns a rendered instance of the component.
+
 #### `widget`
 
 ***In-browser only***
+
+This is an alias for the above `component` getter.
 
 ## Snapshots
 

--- a/src/commands/test/util/browser-tests-runner/BrowserContext.js
+++ b/src/commands/test/util/browser-tests-runner/BrowserContext.js
@@ -4,6 +4,27 @@ var cheerio = require('cheerio');
 var raptorRenderer = require('raptor-renderer');
 var objectAssign = require('object-assign');
 
+function _getRenderedComponent (wrappedRenderResult) {
+  if (!wrappedRenderResult._widget) {
+    var renderedResult = wrappedRenderResult._renderResult
+        .appendTo(document.getElementById('testsTarget'))
+
+    var component;
+    if (renderedResult.getComponent) {
+      // wrappedRenderResult is definitely a v4 component
+      component = renderedResult.getComponent();
+    } else {
+      // pre v4 component
+      component = renderedResult.getWidget();
+    }
+
+    wrappedRenderResult._widget = component
+    wrappedRenderResult.context._mountedWidgets.push(component);
+  }
+
+  return wrappedRenderResult._widget;
+}
+
 function WrappedRenderResult(renderResult, context) {
     this._renderResult = renderResult;
     this.html = renderResult.html;
@@ -22,13 +43,12 @@ WrappedRenderResult.prototype = {
         return this._$;
     },
 
-    get widget() {
-        if (!this._widget) {
-            this._widget = this._renderResult.appendTo(document.getElementById('testsTarget')).getWidget();
-            this.context._mountedWidgets.push(this._widget);
-        }
+    get component() {
+        return _getRenderedComponent(this);
+    },
 
-        return this._widget;
+    get widget() {
+        return _getRenderedComponent(this);
     }
 };
 


### PR DESCRIPTION
Was moving some of my v3 components over to v4 and found that there were an issue creating the components when running tests. Here is a small fix that allows v4 components to be tested when retrieving the `widget` attribute from the browser context. I also added a `component` getter as an alternative alias. I figured that since pretty much all references of "widgets" was replaced with "components" in v4, the `component` attribute would make a more sense for someone who hasn't used an older version of marko.

P.S. Congrats on the release. I'm loving v4 so far and switching from v3 to v4 was a breeze.