### PR TITLE
Adds pluggable testMatcher function in the configuration files

### DIFF
--- a/src/commands/test/util/loadTests.js
+++ b/src/commands/test/util/loadTests.js
@@ -30,7 +30,7 @@ function getRenderer(dir) {
 }
 
 
-function defaultFileMatcher(file) {
+function defaultTestMatcher(file) {
     var testRegExp = /^(?:(.+?)[-.])?(?:spec|test)(?:[-.](server|browser))?[.]/i;
     var basename = path.basename(file);
     var testMatches = testRegExp.exec(basename);
@@ -50,14 +50,14 @@ function defaultFileMatcher(file) {
 function loadTests(dir, patterns, devTools) {
     var tests = [];
     var filesLookup = {};
-    var fileMatcher = devTools.config.fileMatcher || defaultFileMatcher
+    var testMatcher = devTools.config.testMatcher || defaultTestMatcher
 
     function handleFile(file) {
         if (filesLookup[file]) return;
 
-        var matches = fileMatcher(file);
-        if (matches === false) return;
-        var { groupName, env = 'browser' } = matches;
+        var testMatches = testMatcher(file);
+        if (testMatches === false) return;
+        var { groupName, env = 'browser' } = testMatches;
 
 
         filesLookup[file] = true;


### PR DESCRIPTION
This allows users to be able to pass custom testMatchers so one can fine tune which tests are run in each environment. 

This is important because when we have different bundles for mobile/desktop and maybe in the future native? (who knows) we want to be able to only run some tests for some bundles. Currently the behavior has been to run all the tests that follow certain pattern under the `**/test/*.js` blob. We are changing that now.

In this example I'm changing the matcher regular expression for the desktop i.e. large-screen to only accept things like `[utils-]test[.browser|.server].js` and it will not run things like `test.browser.mobile.js` 

but if we run tests with the env variable TEST_PLATFORM set to 'mobile' then our testMatcher will accept *only* tests of the shape `test.browser.mobile.js` :) because there is a separate bundle of javascript files being sent to the tests.

```js
    // Default to Desktop Flag
    const platform = process.env.TEST_PLATFORM;
    const layoutFlag = platform === "mobile" ? "small-screen" : "large-screen";

    markoDevtools.config.testMatcher = (file) => { // eslint-disable-line no-param-reassign
        const largeScreenTextRegExp = /^(?:(.+?)[-.])?(?:spec|test)(?:[-.](server|browser))\.js$/i;
        const smallScreenTextRegExp = /^(?:(.+?)[-.])?(?:spec|test)(?:[-.](server|browser))(?:[-.](mobile))[.]/i;
        const basename = path.basename(file);
        const testMatches = (platform === "mobile" ? smallScreenTextRegExp : largeScreenTextRegExp).exec(basename);

        if (!testMatches) {
            // The file is not a test file
            return false;
        }

        return {
            groupName: testMatches[1],
            env: testMatches[2] || 'browser'
        };
    };

    markoDevtools.configure({
        phantomOptions: { ... },
        browserBuilder: {
            plugins: ....,
            require: { ... },
            flags: ['responsive-on', layoutFlag] // lasso flags when running tests
        }
    });

```