### PR TITLE
create from repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "child-process-promise": "^2.1.3",
     "express": "^4.14.0",
     "glob": "^7.1.0",
+    "got": "^7.0.0",
     "lasso": "*",
     "lasso-istanbul-instrument-transform": "^0.0.4",
     "lasso-marko": "^2.3.0",
@@ -27,12 +28,13 @@
     "mocha": "^2",
     "mocha-phantomjs-core": "^2.1.1",
     "mocha-phantomjs-istanbul": "0.0.2",
-    "nrd": "^1.0.0",
     "object-assign": "^4.1.0",
+    "ora": "^1.2.0",
     "phantomjs-prebuilt": "^2.1.14",
     "porti": "^1.0.2",
     "raptor-renderer": "^1.4.6",
-    "resolve-from": "^2.0.0"
+    "resolve-from": "^2.0.0",
+    "unzip": "^0.1.11"
   },
   "bin": {
     "marko": "bin/marko"

--- a/src/commands/create/run.js
+++ b/src/commands/create/run.js
@@ -28,7 +28,6 @@ module.exports = function run(options, devTools) {
         const repo = parts.repo;
         const tag = parts.tag;
         const fullPath = path.resolve(dir, name);
-        const relativePath = path.relative(process.cwd(), fullPath);
 
         assertAllGood(dir, name, fullPath);
 
@@ -44,9 +43,9 @@ module.exports = function run(options, devTools) {
                     spinner.succeed(
                         'Successfully created app! To get started, run:\n\n'+getRunInstructions(fullPath)+'\n'
                     );
-                })
+                });
             });
-        })
+        });
     }).catch(err => spinner.fail(err.message+'\n'));
 };
 
@@ -130,7 +129,7 @@ function getExistingRepo(org, repo, tag) {
             matchingRepo.tag = tag;
 
             return matchingRepo;
-        })
+        });
     });
 }
 
@@ -145,7 +144,7 @@ function getZipArchive(org, repo, tag, dir, name) {
     let extractor = unzip.Extract({ path: dir });
 
     return new Promise((resolve, reject) => {
-        let zipStream = got.stream(resource).pipe(extractor)
+        let zipStream = got.stream(resource).pipe(extractor);
         zipStream.on('error', reject).on('close', () => {
             fs.renameSync(
                 path.join(dir, repo+'-'+tag),
@@ -181,5 +180,3 @@ function installPackages(fullPath) {
 function getRunInstructions(fullPath) {
     return `cd ${path.relative(process.cwd(), fullPath)}\nnpm start`;
 }
-
-

--- a/src/commands/create/run.js
+++ b/src/commands/create/run.js
@@ -87,7 +87,10 @@ function getExistingRepo(org, repo) {
         } else if(results[2]) {
             matchingRepo = possibleRepos[2];
         } else {
-            throw new Error('Unable to find a matching app template. Tried ' + possibleRepos.join());
+            throw new Error(
+                'Unable to find a matching app template. None of the following exist:\n' +
+                possibleRepos.map(({ org, repo }) => '  - '+org+'/'+repo).join('\n')
+            );
         }
 
         return matchingRepo;

--- a/src/commands/create/run.js
+++ b/src/commands/create/run.js
@@ -109,7 +109,11 @@ function getExistingRepo(org, repo, tag) {
         } else {
             throw new Error(
                 'Unable to find a matching app template. None of the following exist:\n' +
-                possibleRepos.map(({ org, repo }) => '  - '+org+'/'+repo).join('\n')
+                possibleRepos.map((possible) => {
+                    const org = possible.org;
+                    const repo = possible.repo;
+                    return '  - '+org+'/'+repo;
+                }).join('\n')
             );
         }
 
@@ -131,10 +135,9 @@ function getExistingRepo(org, repo, tag) {
 }
 
 function isUrlFound(url) {
-    return got.head(url).then(
-        (response) => true,
-        (error) => false,
-    );
+    return got.head(url)
+        .then((response) => true)
+        .catch((error) => false);
 }
 
 function getZipArchive(org, repo, tag, dir, name) {


### PR DESCRIPTION
This changes `marko create` to download directly from GitHub. 

**Sources**

By default `marko-starter-demo` is used, but you can also specify another repo:

```bash
marko create color-picker:my-new-app # marko-js-samples/marko-color-picker
```

```bash
marko create demo-advanced:my-new-app # marko-js-samples/marko-starter-demo-advanced
```

```bash
marko create ui-components-library:my-new-app # marko-js-samples/ui-component-library
```

```bash
marko create mlrawlings/marko-demo:my-new-app # mlrawlings/marko-demo
```

**Other stuff**

- `marko create` also now runs `npm install` for you.
- progress indicator powered by [ora](https://github.com/sindresorhus/ora)