### PR TITLE
Fixes #39 - Deprecate config options phantomOptions in favor of testO…

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,25 @@ module.exports = function(markoDevTools) {
 }
 ```
 
+### Configuring the test runner
+
+You can easily configure test running using `markoDevTools.config.testOptions`.
+Supported options:
+
+- `timeout` `{Number}`: Timeout for each test. Defaults to `2000`ms.
+- `useColors` `{Boolean}`: Whether the tests should use colors. Defaults to `true`.
+
+_my-app/marko-devtools.js:_
+
+```javascript
+module.exports = function(markoDevTools) {
+    markoDevTools.config.testOptions = {
+        timeout: 5000, // Defaults to 2000ms
+        useColors: true // Defaults to true
+    };
+}
+```
+
 # TODO
 
 - Don't write compiled templates to disk

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chalk": "^1.1.3",
     "cheerio": "^0.22.0",
     "child-process-promise": "^2.1.3",
+    "complain": "^1.0.0",
     "express": "^4.14.0",
     "glob": "^7.1.0",
     "got": "^7.0.0",

--- a/src/commands/test/util/browser-tests-runner/index.js
+++ b/src/commands/test/util/browser-tests-runner/index.js
@@ -16,6 +16,7 @@ var resolveFrom = require('resolve-from');
 var shouldCover = !!process.env.NYC_CONFIG;
 var parseRequire = require('lasso-require/src/util/parseRequire');
 var porti = require('porti');
+const complain = require('complain');
 
 function getCoverageFile() {
     return './.nyc_output/'+Math.floor(Math.random()*100000000)+'.json';
@@ -51,6 +52,19 @@ function startServer(tests, options, devTools) {
         var workDir = devTools.config.workDir;
         var outputDir = path.resolve(workDir, 'browser-build');
         var phantomOptions = devTools.config.phantomOptions;
+        let testOptions = devTools.config.testOptions;
+
+        if (phantomOptions) {
+            complain('"markoDevTools.config.phantomOptions" is deprecated. Please use "markoDevTools.config.testOptions" instead.', {
+                location: path.join(devTools.cwd, 'marko-devtools.js')
+            });
+        }
+
+        if (phantomOptions && testOptions) {
+            return reject(new Error('Using "markoDevTools.config.phantomOptions" with "markoDevTools.config.testOptions" is not permitted. Please just use "markoDevTools.config.testOptions"'));
+        }
+
+        testOptions = testOptions || phantomOptions;
 
         var browserBuilderConfig = Object.assign(
             {
@@ -197,7 +211,7 @@ function startServer(tests, options, devTools) {
 
                 resolve({
                     url,
-                    phantomOptions,
+                    testOptions,
                     stopServer: function() {
                         server.close();
                     }
@@ -219,14 +233,14 @@ exports.run = function(allTests, options, devTools) {
     return startServer(filteredTests, options, devTools)
         .then((result) => {
             console.log(`Running "${result.url}" using mocha-phantomjs...`);
-            var mochaPhantomJSOptions = result.phantomOptions || { useColors: true };
+            let testOptions = result.testOptions || { useColors: true };
 
             if (shouldCover) {
-                mochaPhantomJSOptions.hooks = 'mocha-phantomjs-istanbul';
-                mochaPhantomJSOptions.coverageFile = getCoverageFile();
+                testOptions.hooks = 'mocha-phantomjs-istanbul';
+                testOptions.coverageFile = getCoverageFile();
             }
 
-            return spawn(phantomjsBinPath, [mochaPhantomJSBin, result.url, 'spec', JSON.stringify(mochaPhantomJSOptions)], {
+            return spawn(phantomjsBinPath, [mochaPhantomJSBin, result.url, 'spec', JSON.stringify(testOptions)], {
                 stdio: 'inherit'
             }).then(function() {
                 if(!options.noExit) process.exit(0);


### PR DESCRIPTION
…ptions.

Technically, the options that we support are [here](https://github.com/nathanboktae/mocha-phantomjs-core#config), but since we plan on switching to switching to headless chrome, I wasn't sure which options we wanted to explicitly document. What do you think of `testOptions`?