### PR TITLE
add container getter to browser context

### DIFF
--- a/src/commands/test/util/browser-tests-runner/BrowserContext.js
+++ b/src/commands/test/util/browser-tests-runner/BrowserContext.js
@@ -7,7 +7,7 @@ var objectAssign = require('object-assign');
 function _getRenderedComponent (wrappedRenderResult) {
   if (!wrappedRenderResult._widget) {
     var renderedResult = wrappedRenderResult._renderResult
-        .appendTo(document.getElementById('testsTarget'))
+        .appendTo(wrappedRenderResult.container);
 
     var component;
     if (renderedResult.getComponent) {
@@ -42,7 +42,7 @@ WrappedRenderResult.prototype = {
 
         return this._$;
     },
-    
+
     get container() {
         return document.getElementById('testsTarget');
     }

--- a/src/commands/test/util/browser-tests-runner/BrowserContext.js
+++ b/src/commands/test/util/browser-tests-runner/BrowserContext.js
@@ -42,6 +42,10 @@ WrappedRenderResult.prototype = {
 
         return this._$;
     },
+    
+    get container() {
+        return document.getElementById('testsTarget');
+    }
 
     get component() {
         return _getRenderedComponent(this);


### PR DESCRIPTION
It would be useful to get the underlying dom nodes for a component if a user has functions they wish to test that receive dom elements as input

```js
test('stuff', (ctx) => {
   let container = ctx.render({}).container;
   let parsedInput = parseInputValue(container.querySelector('input'));
   expect(parsedInput).to.equal('foo');
})
```